### PR TITLE
sync: Merge all upstream changes (v0.1.1 → v0.2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Model Context Protocol server that enables Claude Desktop to interact with and v
 - Capture and expose terminal content from any pane
 - Execute commands in tmux panes and retrieve results (use it at your own risk ⚠️)
 - Create new tmux sessions and windows
+- Split panes horizontally or vertically with customizable sizes
 - Kill tmux sessions, windows, and panes
 
 Check out this short video to get excited!
@@ -67,6 +68,7 @@ The MCP server needs to know the shell only when executing commands, to properly
 - `capture-pane` - Capture content from a tmux pane
 - `create-session` - Create a new tmux session
 - `create-window` - Create a new window in a tmux session
+- `split-pane` - Split a tmux pane horizontally or vertically with optional size
 - `kill-session` - Kill a tmux session by ID
 - `kill-window` - Kill a tmux window by ID
 - `kill-pane` - Kill a tmux pane by ID

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Model Context Protocol server that enables Claude Desktop to interact with and v
 - Capture and expose terminal content from any pane
 - Execute commands in tmux panes and retrieve results (use it at your own risk ⚠️)
 - Create new tmux sessions and windows
+- Kill tmux sessions, windows, and panes
 
 Check out this short video to get excited!
 
@@ -66,6 +67,9 @@ The MCP server needs to know the shell only when executing commands, to properly
 - `capture-pane` - Capture content from a tmux pane
 - `create-session` - Create a new tmux session
 - `create-window` - Create a new window in a tmux session
+- `kill-session` - Kill a tmux session by ID
+- `kill-window` - Kill a tmux window by ID
+- `kill-pane` - Kill a tmux pane by ID
 - `execute-command` - Execute a command in a tmux pane
 - `get-command-result` - Get the result of an executed command
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmux-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmux-mcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmux-mcp",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmux-mcp",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "tmux-mcp",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmux-mcp",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.2",
         "uuid": "^11.1.0",
         "zod": "^3.22.4"
+      },
+      "bin": {
+        "tmux-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.10.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmux-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmux-mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP Server for interfacing with tmux sessions",
   "type": "module",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-mcp",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "MCP Server for interfacing with tmux sessions",
   "type": "module",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP Server for interfacing with tmux sessions",
   "type": "module",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP Server for interfacing with tmux sessions",
   "type": "module",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP Server for interfacing with tmux sessions",
   "type": "module",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node build/index.js",
-    "dev": "tsc -w"
+    "dev": "tsc -w",
+    "publish": "npm run build && npm publish --access public"
   },
   "bin": {
     "tmux-mcp": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP Server for interfacing with tmux sessions",
   "type": "module",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "start": "node build/index.js",
     "dev": "tsc -w"
   },
+  "bin": {
+    "tmux-mcp": "build/index.js"
+  },
+  "files": [
+    "build"
+  ],
   "keywords": [
     "mcp",
     "tmux",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "start": "node build/index.js",
     "dev": "tsc -w",
-    "publish": "npm run build && npm publish --access public"
+    "check-release": "npm run build && npm publish --dry-run",
+    "release": "npm run build && npm publish"
   },
   "bin": {
     "tmux-mcp": "build/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import * as tmux from "./tmux.js";
 
 // Create MCP server
 const server = new McpServer({
-  name: "tmux-context",
-  version: "0.1.0"
+  name: "tmux-mcp",
+  version: "0.2.0"
 }, {
   capabilities: {
     resources: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ server.tool(
 // Execute command in pane - Tool
 server.tool(
   "execute-command",
-  "Execute a command in a tmux pane and get results",
+  "Execute a command in a tmux pane and get results. IMPORTANT: Avoid heredoc syntax (cat << EOF) and other multi-line constructs as they conflict with command wrapping. For file writing, prefer: printf 'content\\n' > file, echo statements, or write to temp files instead.",
   {
     paneId: z.string().describe("ID of the tmux pane"),
     command: z.string().describe("Command to execute")

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import * as tmux from "./tmux.js";
 // Create MCP server
 const server = new McpServer({
   name: "tmux-mcp",
-  version: "0.2.1"
+  version: "0.2.2"
 }, {
   capabilities: {
     resources: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import * as tmux from "./tmux.js";
 // Create MCP server
 const server = new McpServer({
   name: "tmux-mcp",
-  version: "0.2.0"
+  version: "0.2.1"
 }, {
   capabilities: {
     resources: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,90 @@ server.tool(
   }
 );
 
+// Kill session - Tool
+server.tool(
+  "kill-session",
+  "Kill a tmux session by ID",
+  {
+    sessionId: z.string().describe("ID of the tmux session to kill")
+  },
+  async ({ sessionId }) => {
+    try {
+      await tmux.killSession(sessionId);
+      return {
+        content: [{
+          type: "text",
+          text: `Session ${sessionId} has been killed`
+        }]
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error killing session: ${error}`
+        }],
+        isError: true
+      };
+    }
+  }
+);
+
+// Kill window - Tool
+server.tool(
+  "kill-window",
+  "Kill a tmux window by ID",
+  {
+    windowId: z.string().describe("ID of the tmux window to kill")
+  },
+  async ({ windowId }) => {
+    try {
+      await tmux.killWindow(windowId);
+      return {
+        content: [{
+          type: "text",
+          text: `Window ${windowId} has been killed`
+        }]
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error killing window: ${error}`
+        }],
+        isError: true
+      };
+    }
+  }
+);
+
+// Kill pane - Tool
+server.tool(
+  "kill-pane",
+  "Kill a tmux pane by ID",
+  {
+    paneId: z.string().describe("ID of the tmux pane to kill")
+  },
+  async ({ paneId }) => {
+    try {
+      await tmux.killPane(paneId);
+      return {
+        content: [{
+          type: "text",
+          text: `Pane ${paneId} has been killed`
+        }]
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error killing pane: ${error}`
+        }],
+        isError: true
+      };
+    }
+  }
+);
+
 // Execute command in pane - Tool
 server.tool(
   "execute-command",

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,37 +340,37 @@ server.resource(
   "Tmux Pane Content",
   new ResourceTemplate("tmux://pane/{paneId}", {
     list: async () => {
-    try {
-    // Get all sessions
-    const sessions = await tmux.listSessions();
-    const paneResources = [];
+      try {
+        // Get all sessions
+        const sessions = await tmux.listSessions();
+        const paneResources = [];
 
-    // For each session, get all windows
-    for (const session of sessions) {
-    const windows = await tmux.listWindows(session.id);
+        // For each session, get all windows
+        for (const session of sessions) {
+          const windows = await tmux.listWindows(session.id);
 
-    // For each window, get all panes
-    for (const window of windows) {
-    const panes = await tmux.listPanes(window.id);
+          // For each window, get all panes
+          for (const window of windows) {
+            const panes = await tmux.listPanes(window.id);
 
-    // For each pane, create a resource with descriptive name
-    for (const pane of panes) {
-    paneResources.push({
-      name: `Pane: ${session.name} - ${pane.id} - ${pane.title} ${pane.active ? "(active)" : ""}`,
-        uri: `tmux://pane/${pane.id}`,
-          description: `Content from pane ${pane.id} - ${pane.title} in session ${session.name}`
-          });
-         }
-     }
-     }
+            // For each pane, create a resource with descriptive name
+            for (const pane of panes) {
+              paneResources.push({
+                name: `Pane: ${session.name} - ${pane.id} - ${pane.title} ${pane.active ? "(active)" : ""}`,
+                uri: `tmux://pane/${pane.id}`,
+                description: `Content from pane ${pane.id} - ${pane.title} in session ${session.name}`
+              });
+            }
+          }
+        }
 
-    return {
-        resources: paneResources
+        return {
+          resources: paneResources
         };
       } catch (error) {
         server.server.sendLoggingMessage({
-            level: 'error',
-            data: `Error listing panes: ${error}`
+          level: 'error',
+          data: `Error listing panes: ${error}`
         });
 
         return { resources: [] };
@@ -476,17 +476,6 @@ async function main() {
     tmux.setShellConfig({
       type: values['shell-type'] as string
     });
-
-    // Check if tmux is running
-    const tmuxRunning = await tmux.isTmuxRunning();
-    if (!tmuxRunning) {
-      server.server.sendLoggingMessage({
-          level: 'error',
-          data: 'Tmux seems not running'
-      });
-
-      throw "Tmux server is not running";
-    }
 
     // Start the MCP server
     const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { parseArgs } from 'node:util';
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,6 +311,38 @@ server.tool(
   }
 );
 
+// Split pane - Tool
+server.tool(
+  "split-pane",
+  "Split a tmux pane horizontally or vertically",
+  {
+    paneId: z.string().describe("ID of the tmux pane to split"),
+    direction: z.enum(["horizontal", "vertical"]).optional().describe("Split direction: 'horizontal' (side by side) or 'vertical' (top/bottom). Default is 'vertical'"),
+    size: z.number().min(1).max(99).optional().describe("Size of the new pane as percentage (1-99). Default is 50%")
+  },
+  async ({ paneId, direction, size }) => {
+    try {
+      const newPane = await tmux.splitPane(paneId, direction || 'vertical', size);
+      return {
+        content: [{
+          type: "text",
+          text: newPane
+            ? `Pane split successfully. New pane: ${JSON.stringify(newPane, null, 2)}`
+            : `Failed to split pane ${paneId}`
+        }]
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error splitting pane: ${error}`
+        }],
+        isError: true
+      };
+    }
+  }
+);
+
 // Execute command in pane - Tool
 server.tool(
   "execute-command",

--- a/src/index.ts
+++ b/src/index.ts
@@ -607,13 +607,49 @@ server.resource(
   }
 );
 
+function showHelp() {
+  console.log(`
+tmux-mcp v0.2.2
+MCP Server for interfacing with tmux sessions
+
+USAGE:
+  tmux-mcp [OPTIONS]
+
+OPTIONS:
+  -s, --shell-type <TYPE>  Shell type to use for command execution
+                           Options: bash, zsh, fish
+                           Default: bash
+
+  -h, --help              Show this help message and exit
+
+DESCRIPTION:
+  A Model Context Protocol server that enables AI assistants to interact
+  with tmux sessions. Provides tools and resources for reading terminal
+  content, executing commands, and managing tmux sessions/windows/panes.
+
+EXAMPLES:
+  tmux-mcp                      # Start with default bash shell
+  tmux-mcp --shell-type=zsh     # Start with zsh shell type
+  tmux-mcp -s fish              # Start with fish shell type
+
+For more information, visit: https://github.com/nickgnd/tmux-mcp
+`);
+}
+
 async function main() {
   try {
     const { values } = parseArgs({
       options: {
-        'shell-type': { type: 'string', default: 'bash', short: 's' }
+        'shell-type': { type: 'string', default: 'bash', short: 's' },
+        'help': { type: 'boolean', short: 'h' }
       }
     });
+
+    // Show help if requested
+    if (values.help) {
+      showHelp();
+      process.exit(0);
+    }
 
     // Set shell configuration
     tmux.setShellConfig({

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -151,8 +151,9 @@ export async function listPanes(windowId: string): Promise<TmuxPane[]> {
 /**
  * Capture content from a specific pane, by default the latest 200 lines.
  */
-export async function capturePaneContent(paneId: string, lines: number = 200): Promise<string> {
-  return executeTmux(`capture-pane -p -t '${paneId}' -S -${lines} -E -`);
+export async function capturePaneContent(paneId: string, lines: number = 200, includeColors: boolean = false): Promise<string> {
+  const colorFlag = includeColors ? '-e' : '';
+  return executeTmux(`capture-pane -p ${colorFlag} -t '${paneId}' -S -${lines} -E -`);
 }
 
 /**

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -173,6 +173,27 @@ export async function createWindow(sessionId: string, name: string): Promise<Tmu
   return windows.find(window => window.name === name) || null;
 }
 
+/**
+ * Kill a tmux session by ID
+ */
+export async function killSession(sessionId: string): Promise<void> {
+  await executeTmux(`kill-session -t '${sessionId}'`);
+}
+
+/**
+ * Kill a tmux window by ID
+ */
+export async function killWindow(windowId: string): Promise<void> {
+  await executeTmux(`kill-window -t '${windowId}'`);
+}
+
+/**
+ * Kill a tmux pane by ID
+ */
+export async function killPane(paneId: string): Promise<void> {
+  await executeTmux(`kill-pane -t '${paneId}'`);
+}
+
 // Map to track ongoing command executions
 const activeCommands = new Map<string, CommandExecution>();
 


### PR DESCRIPTION
## Summary

本家nickgnd/tmux-mcpから17個のコミット（16個の機能追加・改善 + 1個のリリース）をすべて取り込みます。

主な機能追加:
• ✨ **noEnterモード**: TUIアプリ（vim, btop, less等）との適切なインタラクション
• 🗑️ **kill機能**: tmuxセッション、ウィンドウ、ペインの削除ツール
• 📱 **ペイン分割**: 垂直・水平でのペイン分割機能
• 🎨 **色付きキャプチャ**: ペインキャプチャ時の色情報保持
• ⚡ **rawModeパラメータ**: インタラクティブコマンド実行のサポート
• 🚀 **起動改善**: tmuxが起動していなくてもMCPサーバーが起動可能に

バージョン: v0.1.1 → v0.2.2

## Test plan

- [x] TypeScriptビルドの成功
- [x] 型チェックの通過  
- [x] サーバー起動確認
- [x] パッケージ依存関係の解決

🤖 Generated with [Claude Code](https://claude.ai/code)