### PR TITLE
chore: setup npm package as @kazuph/mcp-tmux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tmux-mcp",
+  "name": "@kazuph/mcp-tmux",
   "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tmux-mcp",
+      "name": "@kazuph/mcp-tmux",
       "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
@@ -14,7 +14,7 @@
         "zod": "^3.22.4"
       },
       "bin": {
-        "tmux-mcp": "build/index.js"
+        "mcp-tmux": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.10.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tmux-mcp",
+  "name": "@kazuph/mcp-tmux",
   "version": "0.2.2",
   "description": "MCP Server for interfacing with tmux sessions",
   "type": "module",
@@ -8,11 +8,12 @@
     "build": "tsc",
     "start": "node build/index.js",
     "dev": "tsc -w",
-    "check-release": "npm run build && npm publish --dry-run",
-    "release": "npm run build && npm publish"
+    "prepublishOnly": "npm run build",
+    "check-release": "npm publish --dry-run",
+    "release": "npm publish"
   },
   "bin": {
-    "tmux-mcp": "build/index.js"
+    "mcp-tmux": "build/index.js"
   },
   "files": [
     "build"
@@ -22,7 +23,7 @@
     "tmux",
     "claude"
   ],
-  "author": "nickgnd",
+  "author": "kazuph",
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.2",
@@ -34,12 +35,15 @@
     "@types/uuid": "^10.0.0",
     "typescript": "^5.3.3"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nickgnd/tmux-mcp.git"
+    "url": "git+https://github.com/kazuph/mcp-tmux.git"
   },
   "bugs": {
-    "url": "https://github.com/nickgnd/tmux-mcp/issues"
+    "url": "https://github.com/kazuph/mcp-tmux/issues"
   },
-  "homepage": "https://github.com/nickgnd/tmux-mcp#readme"
+  "homepage": "https://github.com/kazuph/mcp-tmux#readme"
 }


### PR DESCRIPTION
## Summary

npm publishできるようにpackage.jsonを設定しました。

## Changes

- ✨ **パッケージ名変更**: `tmux-mcp` → `@kazuph/mcp-tmux`
- 🔧 **自動ビルド設定**: `prepublishOnly`スクリプトを追加（publish前に自動でビルドが実行される）
- 📦 **パブリック公開設定**: `publishConfig`で`access: public`を設定
- 👤 **著者情報更新**: author を kazuph に変更
- 🔗 **リポジトリURL更新**: kazuph/mcp-tmux に変更
- 📝 **bin名変更**: `mcp-tmux`に統一

## Test

```bash
# dry-runで確認済み
npm publish --dry-run
```

✅ prepublishOnlyスクリプトが正常に動作してビルドが自動実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)